### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,19 +2,16 @@ class ApplicationController < ActionController::Base
   before_action :basic_auth
   before_action :configure_permitted_parameters, if: :devise_controller?
 
-
-
-
-
   private
 
   def basic_auth
     authenticate_or_request_with_http_basic do |username, password|
-      username == ENV["BASIC_AUTH_USER"] && password == ENV["BASIC_AUTH_PASSWORD"]
+      username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']
     end
   end
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname, :last_name, :first_name, :last_name_kana, :first_name_kana, :birthday])
+    devise_parameter_sanitizer.permit(:sign_up,
+                                      keys: [:nickname, :last_name, :first_name, :last_name_kana, :first_name_kana, :birthday])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,6 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    @items = Item.all
     @items = Item.all.order(created_at: :desc)
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,7 +7,7 @@ class ItemsController < ApplicationController
   end
 
   def new
-    @item =Item.new
+    @item = Item.new
   end
 
   def create
@@ -22,6 +22,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:image,:product_name,:product_description,:price,:category_id,:condition_id,:shipping_fee_id,:prefecture_id,:shipping_day_id).merge(user_id: current_user.id)
+    params.require(:item).permit(:image, :product_name, :product_description, :price, :category_id, :condition_id, :shipping_fee_id,
+                                 :prefecture_id, :shipping_day_id).merge(user_id: current_user.id)
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,8 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    # @items = Item.all
+    @items = Item.all
+    @items = Item.all.order(created_at: :desc)
   end
 
   def new

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -15,4 +15,4 @@ class Category < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-  end
+end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -11,4 +11,4 @@ class Condition < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,13 +6,14 @@ class Item < ApplicationRecord
 
   validates :product_name, presence: true
   validates :product_description, presence: true
-  validates :price, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999}
+  validates :price, presence: true,
+                    numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }
 
-  validates :category_id, numericality: { other_than: 1 , message: "can't be blank"}
-  validates :condition_id, numericality: { other_than: 1 , message: "can't be blank"}
-  validates :shipping_fee_id, numericality: { other_than: 1 , message: "can't be blank"}
-  validates :prefecture_id, numericality: { other_than: 1 , message: "can't be blank"}
-  validates :shipping_day_id, numericality: { other_than: 1 , message: "can't be blank"}
+  validates :category_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :condition_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :shipping_fee_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :prefecture_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :shipping_day_id, numericality: { other_than: 1, message: "can't be blank" }
 
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to :category
@@ -20,5 +21,4 @@ class Item < ApplicationRecord
   belongs_to :condition
   belongs_to :prefecture
   belongs_to :shipping_day
-
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,19 +1,19 @@
 class Prefecture < ActiveHash::Base
   self.data = [
-    {id: 1, name: '---'},{id: 2, name: '北海道'},{id: 3, name: '青森県'},{id: 4, name: '岩手県'},
-    {id: 5, name: '宮城県'},{id: 6, name: '秋田県'},{id: 7, name: '山形県'},{id: 8, name: '福島県'},
-    {id: 9, name: '茨城県'},{id: 10, name: '栃木県'},{id: 11, name: '群馬県'}, {id: 12, name: '埼玉県'},
-    {id: 13, name: '千葉県'},{id: 14, name: '東京都'},{id: 15, name: '神奈川県'},{id: 16, name: '新潟県'},
-    {id: 17, name: '富山県'},{id: 18, name: '石川県'},{id: 19, name: '福井県'},{id: 20, name: '山梨県'},
-    {id: 21, name: '長野県'},{id: 22, name: '岐阜県'},{id: 23, name: '静岡県'},{id: 24, name: '愛知県'},
-    {id: 25, name: '三重県'},{id: 26, name: '滋賀県'},{id: 27, name: '京都府'},{id: 28, name: '大阪府'},
-    {id: 29, name: '兵庫県'},{id: 30, name: '奈良県'},{id: 31, name: '和歌山県'},{id: 32, name: '鳥取県'},
-    {id: 33, name: '島根県'},{id: 34, name: '岡山県'},{id: 35, name: '広島県'},{id: 36, name: '山口県'},
-    {id: 37, name: '徳島県'},{id: 38, name: '香川県'},{id: 39, name: '愛媛県'},{id: 40, name: '高知県'},
-    {id: 41, name: '福岡県'},{id: 42, name: '佐賀県'},{id: 43, name: '長崎県'},{id: 44, name: '熊本県'},
-    {id: 45, name: '大分県'},{id: 46, name: '宮崎県'},{id: 47, name: '鹿児島県'},{id: 48, name: '沖縄県'}
+    { id: 1, name: '---' }, { id: 2, name: '北海道' }, { id: 3, name: '青森県' }, { id: 4, name: '岩手県' },
+    { id: 5, name: '宮城県' }, { id: 6, name: '秋田県' }, { id: 7, name: '山形県' }, { id: 8, name: '福島県' },
+    { id: 9, name: '茨城県' }, { id: 10, name: '栃木県' }, { id: 11, name: '群馬県' }, { id: 12, name: '埼玉県' },
+    { id: 13, name: '千葉県' }, { id: 14, name: '東京都' }, { id: 15, name: '神奈川県' }, { id: 16, name: '新潟県' },
+    { id: 17, name: '富山県' }, { id: 18, name: '石川県' }, { id: 19, name: '福井県' }, { id: 20, name: '山梨県' },
+    { id: 21, name: '長野県' }, { id: 22, name: '岐阜県' }, { id: 23, name: '静岡県' }, { id: 24, name: '愛知県' },
+    { id: 25, name: '三重県' }, { id: 26, name: '滋賀県' }, { id: 27, name: '京都府' }, { id: 28, name: '大阪府' },
+    { id: 29, name: '兵庫県' }, { id: 30, name: '奈良県' }, { id: 31, name: '和歌山県' }, { id: 32, name: '鳥取県' },
+    { id: 33, name: '島根県' }, { id: 34, name: '岡山県' }, { id: 35, name: '広島県' }, { id: 36, name: '山口県' },
+    { id: 37, name: '徳島県' }, { id: 38, name: '香川県' }, { id: 39, name: '愛媛県' }, { id: 40, name: '高知県' },
+    { id: 41, name: '福岡県' }, { id: 42, name: '佐賀県' }, { id: 43, name: '長崎県' }, { id: 44, name: '熊本県' },
+    { id: 45, name: '大分県' }, { id: 46, name: '宮崎県' }, { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
   ]
 
   include ActiveHash::Associations
   has_many :items
-  end
+end

--- a/app/models/shipping_day.rb
+++ b/app/models/shipping_day.rb
@@ -8,4 +8,4 @@ class ShippingDay < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-  end
+end

--- a/app/models/shipping_fee.rb
+++ b/app/models/shipping_fee.rb
@@ -7,4 +7,4 @@ class ShippingFee < ActiveHash::Base
 
   include ActiveHash::Associations
   has_many :items
-  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,18 +4,18 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-         validates :nickname, presence: true
+  validates :nickname, presence: true
 
-         with_options presence: true, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/ } do
-          validates :first_name
-          validates :last_name
-        end
-        with_options presence: true, format: { with: /\A[ァ-ヶー－]+\z/ } do
-          validates :first_name_kana
-          validates :last_name_kana
-        end
-         validates :birthday, presence: true
-         validates :password, format: { with: /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i }
+  with_options presence: true, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/ } do
+    validates :first_name
+    validates :last_name
+  end
+  with_options presence: true, format: { with: /\A[ァ-ヶー－]+\z/ } do
+    validates :first_name_kana
+    validates :last_name_kana
+  end
+  validates :birthday, presence: true
+  validates :password, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i }
 
-         has_many :items
+  has_many :items
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,14 +127,12 @@
       新規投稿商品
     </div>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <%# <% if @items.present? %>
-      <%# <% @items.each do |item| %>
+      <% if @items.present? %>
+      <% @items.each do |item| %>
       <li class='list'>
-        <%# <%= link_to item_path(item.id) do %>
+        <%= link_to items_path(item.id) do %>
         <div class='item-img-content'>
-          <%# <%= image_tag item.image, class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -145,11 +143,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%# <%= itme.product_name %>
+            <%= item.product_name %>
           </h3>
           <div class='item-price'>
-            <%# <span><%= item.price %>円<br>
-            <%# <%= item.shipping_fee %></span> 
+            <span><%= item.price %>円<br><%= item.shipping_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -157,13 +154,9 @@
           </div>
         </div>
       </li>
-      <%# <% end %>
-      <%# <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <%# <% else %>
+      <% end %>
+      <% end %>
+      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -180,10 +173,8 @@
           </div>
         </div>
       </li>
-      <%# <% end %> %>
       <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :item do
-    product_name          {Faker::Name.initials(number: 2)}
-    product_description   {Faker::Name.initials(number: 2)}
-    category_id           {Faker::Number.between(from: 2, to: 11)}
-    condition_id          {Faker::Number.between(from: 2, to: 7)}
-    shipping_fee_id       {Faker::Number.between(from: 2, to: 3)}
-    prefecture_id         {Faker::Number.between(from: 2, to: 48)}
-    shipping_day_id       {Faker::Number.between(from: 2, to: 4)}
-    price                 {Faker::Number.between(from: 300, to: 9999999)}
+    product_name          { Faker::Name.initials(number: 2) }
+    product_description   { Faker::Name.initials(number: 2) }
+    category_id           { Faker::Number.between(from: 2, to: 11) }
+    condition_id          { Faker::Number.between(from: 2, to: 7) }
+    shipping_fee_id       { Faker::Number.between(from: 2, to: 3) }
+    prefecture_id         { Faker::Number.between(from: 2, to: 48) }
+    shipping_day_id       { Faker::Number.between(from: 2, to: 4) }
+    price                 { Faker::Number.between(from: 300, to: 9_999_999) }
 
     association :user
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,13 +1,13 @@
 FactoryBot.define do
   factory :user do
-    nickname              {Faker::Name.initials(number: 2)}
-    email                 {Faker::Internet.free_email}
-    password              {Faker::Lorem.characters(number: 6, min_alpha: 1, min_numeric: 1) }
-    password_confirmation {password}
-    last_name             {'山田ヤマダやまだ'}
-    first_name            {'山田ヤマダやまだ'}
-    last_name_kana        {'テスト'}
-    first_name_kana       {'テスト'}
-    birthday              {Faker::Date.birthday}
+    nickname              { Faker::Name.initials(number: 2) }
+    email                 { Faker::Internet.free_email }
+    password              { Faker::Lorem.characters(number: 6, min_alpha: 1, min_numeric: 1) }
+    password_confirmation { password }
+    last_name             { '山田ヤマダやまだ' }
+    first_name            { '山田ヤマダやまだ' }
+    last_name_kana        { 'テスト' }
+    first_name_kana       { 'テスト' }
+    birthday              { Faker::Date.birthday }
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -4,84 +4,84 @@ RSpec.describe Item, type: :model do
   before do
     @item = FactoryBot.build(:item)
   end
-  
-  describe "商品出品機能" do
+
+  describe '商品出品機能' do
     context '商品出品がうまくいくとき' do
-      it "image,item_name,description,category_id,status_id,prefecture_id,delivery_fee_payment_id,delivery_prepare_id,priceの値が存在すれば登録できること" do
+      it 'image,item_name,description,category_id,status_id,prefecture_id,delivery_fee_payment_id,delivery_prepare_id,priceの値が存在すれば登録できること' do
         expect(@item).to be_valid
       end
-      it "priceが300(半角数字)であれば登録できる" do
+      it 'priceが300(半角数字)であれば登録できる' do
         @item.price = '300'
         expect(@item).to be_valid
       end
-      it "priceが9999999(半角数字)であれば登録できる" do
+      it 'priceが9999999(半角数字)であれば登録できる' do
         @item.price = '9999999'
         expect(@item).to be_valid
       end
     end
 
     context '商品出品がうまくいかないとき' do
-      it "imageが空では登録できない" do
+      it 'imageが空では登録できない' do
         @item.image = nil
         @item.valid?
         expect(@item.errors.full_messages).to include "Image can't be blank"
       end
-      it "product_nameが空では登録できない" do
+      it 'product_nameが空では登録できない' do
         @item.product_name = nil
         @item.valid?
         expect(@item.errors.full_messages).to include "Product name can't be blank"
       end
-      it "priceが空では登録できない" do
+      it 'priceが空では登録できない' do
         @item.price = nil
         @item.valid?
         expect(@item.errors.full_messages).to include "Price can't be blank"
       end
-      it "priceが300未満では登録できない" do
+      it 'priceが300未満では登録できない' do
         @item.price = '299'
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price must be greater than or equal to 300"
+        expect(@item.errors.full_messages).to include 'Price must be greater than or equal to 300'
       end
-      it "priceが9999999より高いと登録できない" do
+      it 'priceが9999999より高いと登録できない' do
         @item.price = '10000000'
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price must be less than or equal to 9999999"
+        expect(@item.errors.full_messages).to include 'Price must be less than or equal to 9999999'
       end
-      it "priceが全角では登録できない" do
+      it 'priceが全角では登録できない' do
         @item.price = '３００'
         @item.valid?
-        expect(@item.errors.full_messages).to include "Price is not a number"
+        expect(@item.errors.full_messages).to include 'Price is not a number'
       end
-      it "category_idが1では登録できない" do
+      it 'category_idが1では登録できない' do
         @item.category_id = '1'
         @item.valid?
         expect(@item.errors.full_messages).to include "Category can't be blank"
       end
-      it "condition_idが1では登録できない" do
+      it 'condition_idが1では登録できない' do
         @item.condition_id = '1'
         @item.valid?
         expect(@item.errors.full_messages).to include "Condition can't be blank"
       end
-      it "shipping_fee_idが1では登録できない" do
+      it 'shipping_fee_idが1では登録できない' do
         @item.shipping_fee_id = '1'
         @item.valid?
         expect(@item.errors.full_messages).to include "Shipping fee can't be blank"
       end
-      it "prefecture_idが1では登録できない" do
+      it 'prefecture_idが1では登録できない' do
         @item.prefecture_id = '1'
         @item.valid?
         expect(@item.errors.full_messages).to include "Prefecture can't be blank"
       end
-      it "shipping_day_idが1では登録できない" do
+      it 'shipping_day_idが1では登録できない' do
         @item.shipping_day_id = '1'
         @item.valid?
         expect(@item.errors.full_messages).to include "Shipping day can't be blank"
       end
-      it "ユーザーが紐付いていなければ投稿できない" do
+      it 'ユーザーが紐付いていなければ投稿できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include "User must exist"
+        expect(@item.errors.full_messages).to include 'User must exist'
       end
-      it "商品説明が空では登録できない" do
+      it '商品説明が空では登録できない' do
         @item.product_description = nil
         @item.valid?
         expect(@item.errors.full_messages).to include "Product description can't be blank"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,22 +5,22 @@ RSpec.describe User, type: :model do
     @user = FactoryBot.build(:user)
   end
 
-  describe "新規登録/ユーザー情報" do
+  describe '新規登録/ユーザー情報' do
     context '新規登録がうまくいくとき' do
-      it "nickname、email、password、password_confirmation、last_name、first_name、last_name_kana、first_name_kana、birthdayが存在すれば登録できる" do
+      it 'nickname、email、password、password_confirmation、last_name、first_name、last_name_kana、first_name_kana、birthdayが存在すれば登録できる' do
         expect(@user).to be_valid
       end
-      it "last_name、first_nameが全角（漢字・カタカナ・ひらがな）であれば登録できる" do
+      it 'last_name、first_nameが全角（漢字・カタカナ・ひらがな）であれば登録できる' do
         @user.last_name = '漢字カタカナひらがな'
         @user.first_name = '漢字カタカナひらがな'
         expect(@user).to be_valid
       end
-      it "last_name_kana、first_name_kanaが全角カタカナであれば登録できる" do
+      it 'last_name_kana、first_name_kanaが全角カタカナであれば登録できる' do
         @user.last_name_kana = 'カタカナ'
         @user.first_name_kana = 'カタカナ'
         expect(@user).to be_valid
       end
-      it "password、password_confirmationが6文字以上の半角英数字であれば登録できる" do
+      it 'password、password_confirmationが6文字以上の半角英数字であれば登録できる' do
         @user.password = '123abc'
         @user.password_confirmation = '123abc'
         expect(@user).to be_valid
@@ -28,139 +28,139 @@ RSpec.describe User, type: :model do
     end
 
     context '新規登録がうまくいかないとき' do
-      it "nicknameが空だと登録できない" do
+      it 'nicknameが空だと登録できない' do
         @user.nickname = nil
         @user.valid?
         expect(@user.errors.full_messages).to include "Nickname can't be blank"
       end
-      it "emailが空では登録できない" do
+      it 'emailが空では登録できない' do
         @user.email = nil
         @user.valid?
         expect(@user.errors.full_messages).to include "Email can't be blank"
       end
-      it "登録されたemailでは登録できない" do
+      it '登録されたemailでは登録できない' do
         @user.save
         another_user = FactoryBot.build(:user)
         another_user.email = @user.email
         another_user.valid?
-        expect(another_user.errors.full_messages).to include "Email has already been taken"
+        expect(another_user.errors.full_messages).to include 'Email has already been taken'
       end
-      it "emailに@を含まないと登録できない" do
+      it 'emailに@を含まないと登録できない' do
         @user.email = '123456'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Email is invalid"
+        expect(@user.errors.full_messages).to include 'Email is invalid'
       end
-      it "password空では登録できない" do
+      it 'password空では登録できない' do
         @user.password = nil
         @user.password_confirmation = nil
         @user.valid?
         expect(@user.errors.full_messages).to include "Password can't be blank"
       end
-      it "passwordが6文字以上でないと登録できない" do
+      it 'passwordが6文字以上でないと登録できない' do
         @user.password = '123ab'
         @user.password_confirmation = '123ab'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password is too short (minimum is 6 characters)"
+        expect(@user.errors.full_messages).to include 'Password is too short (minimum is 6 characters)'
       end
-      it "passwordは半角数字だけでは登録できない" do
+      it 'passwordは半角数字だけでは登録できない' do
         @user.password = '123456'
         @user.password_confirmation = '123456'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password is invalid"
+        expect(@user.errors.full_messages).to include 'Password is invalid'
       end
-      it "passwordは半角英字だけでは登録できない" do
+      it 'passwordは半角英字だけでは登録できない' do
         @user.password = 'abcdef'
         @user.password_confirmation = 'abcdef'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password is invalid"
+        expect(@user.errors.full_messages).to include 'Password is invalid'
       end
-      it "passwordは全角英数字混合では登録できない" do
+      it 'passwordは全角英数字混合では登録できない' do
         @user.password = '１２３ａｂｅ'
         @user.password_confirmation = '１２３ａｂｅ'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Password is invalid"
+        expect(@user.errors.full_messages).to include 'Password is invalid'
       end
-      it "passwordとpassword_confirmationが一致しないと登録できない" do
+      it 'passwordとpassword_confirmationが一致しないと登録できない' do
         @user.password = '123abc'
         @user.password_confirmation = 'abc123'
         @user.valid?
         expect(@user.errors.full_messages).to include "Password confirmation doesn't match Password"
       end
-      it "お名前(全角)は、名字が空だと登録できない" do
+      it 'お名前(全角)は、名字が空だと登録できない' do
         @user.last_name = nil
         @user.valid?
         expect(@user.errors.full_messages).to include "Last name can't be blank"
       end
-      it "お名前(全角)は、名前が空だと登録できない" do
+      it 'お名前(全角)は、名前が空だと登録できない' do
         @user.first_name = nil
         @user.valid?
         expect(@user.errors.full_messages).to include "First name can't be blank"
       end
-      it " お名前(全角)は、全角数字では登録できない" do
+      it ' お名前(全角)は、全角数字では登録できない' do
         @user.first_name = '１'
         @user.last_name = '１'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name is invalid", "First name is invalid"
+        expect(@user.errors.full_messages).to include 'Last name is invalid', 'First name is invalid'
       end
-      it " お名前(全角)は、全角英字では登録できない" do
+      it ' お名前(全角)は、全角英字では登録できない' do
         @user.first_name = 'ａ'
         @user.last_name = 'ａ'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name is invalid", "First name is invalid"
+        expect(@user.errors.full_messages).to include 'Last name is invalid', 'First name is invalid'
       end
-      it " お名前(全角)は、半角数字では登録できない" do
+      it ' お名前(全角)は、半角数字では登録できない' do
         @user.first_name = '1'
         @user.last_name = '1'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name is invalid", "First name is invalid"
+        expect(@user.errors.full_messages).to include 'Last name is invalid', 'First name is invalid'
       end
-      it " お名前(全角)は、半角英字では登録できない" do
+      it ' お名前(全角)は、半角英字では登録できない' do
         @user.first_name = 'a'
         @user.last_name = 'a'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name is invalid", "First name is invalid"
+        expect(@user.errors.full_messages).to include 'Last name is invalid', 'First name is invalid'
       end
-      it " お名前(全角)は、半角カナでは登録できない" do
+      it ' お名前(全角)は、半角カナでは登録できない' do
         @user.first_name = 'ｱ'
         @user.last_name = 'ｱ'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name is invalid", "First name is invalid"
+        expect(@user.errors.full_messages).to include 'Last name is invalid', 'First name is invalid'
       end
-      it "お名前カナ(全角)は、名字が空では登録できない" do
+      it 'お名前カナ(全角)は、名字が空では登録できない' do
         @user.last_name = nil
         @user.valid?
         expect(@user.errors.full_messages).to include "Last name can't be blank"
       end
-      it "お名前カナ(全角)は、名前が空では登録できない" do
+      it 'お名前カナ(全角)は、名前が空では登録できない' do
         @user.first_name = nil
         @user.valid?
         expect(@user.errors.full_messages).to include "First name can't be blank"
       end
-      it "お名前カナ(全角)は、全角（漢字）では登録できない" do
+      it 'お名前カナ(全角)は、全角（漢字）では登録できない' do
         @user.first_name_kana = '漢字'
         @user.last_name_kana = '漢字'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name kana is invalid", "First name kana is invalid"
+        expect(@user.errors.full_messages).to include 'Last name kana is invalid', 'First name kana is invalid'
       end
-      it "お名前カナ(全角)は、全角（ひらがな）では登録できない" do
+      it 'お名前カナ(全角)は、全角（ひらがな）では登録できない' do
         @user.first_name_kana = 'ひらがな'
         @user.last_name_kana = 'ひらがな'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name kana is invalid", "First name kana is invalid"
+        expect(@user.errors.full_messages).to include 'Last name kana is invalid', 'First name kana is invalid'
       end
-      it "お名前カナ(全角)は、全角（英字）では登録できない" do
+      it 'お名前カナ(全角)は、全角（英字）では登録できない' do
         @user.first_name_kana = 'ａ'
         @user.last_name_kana = 'ａ'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name kana is invalid", "First name kana is invalid"
+        expect(@user.errors.full_messages).to include 'Last name kana is invalid', 'First name kana is invalid'
       end
-      it "お名前カナ(全角)は、全角（数字）では登録できない" do
+      it 'お名前カナ(全角)は、全角（数字）では登録できない' do
         @user.first_name_kana = '１'
         @user.last_name_kana = '１'
         @user.valid?
-        expect(@user.errors.full_messages).to include "Last name kana is invalid", "First name kana is invalid"
+        expect(@user.errors.full_messages).to include 'Last name kana is invalid', 'First name kana is invalid'
       end
-      it "生年月日ががないと登録できない" do
+      it '生年月日ががないと登録できない' do
         @user.birthday = nil
         @user.valid?
         expect(@user.errors.full_messages).to include "Birthday can't be blank"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
-abort("The Rails environment is running in production mode!") if Rails.env.production?
+abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,51 +44,49 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
-# The settings below are suggested to provide a good initial experience
-# with RSpec, but feel free to customize to your heart's content.
-=begin
-  # This allows you to limit a spec run to individual examples or groups
-  # you care about by tagging them with `:focus` metadata. When nothing
-  # is tagged with `:focus`, all examples get run. RSpec also provides
-  # aliases for `it`, `describe`, and `context` that include `:focus`
-  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching :focus
-
-  # Allows RSpec to persist some state between runs in order to support
-  # the `--only-failures` and `--next-failure` CLI options. We recommend
-  # you configure your source control system to ignore this file.
-  config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  # https://relishapp.com/rspec/rspec-core/docs/configuration/zero-monkey-patching-mode
-  config.disable_monkey_patching!
-
-  # Many RSpec users commonly either run the entire suite or an individual
-  # file, and it's useful to allow more verbose output when running an
-  # individual spec file.
-  if config.files_to_run.one?
-    # Use the documentation formatter for detailed output,
-    # unless a formatter has already been configured
-    # (e.g. via a command-line flag).
-    config.default_formatter = "doc"
-  end
-
-  # Print the 10 slowest examples and example groups at the
-  # end of the spec run, to help surface which specs are running
-  # particularly slow.
-  config.profile_examples = 10
-
-  # Run specs in random order to surface order dependencies. If you find an
-  # order dependency and want to debug it, you can fix the order by providing
-  # the seed, which is printed after each run.
-  #     --seed 1234
-  config.order = :random
-
-  # Seed global randomization in this process using the `--seed` CLI option.
-  # Setting this allows you to use `--seed` to deterministically reproduce
-  # test failures related to randomization by passing the same `--seed` value
-  # as the one that triggered the failure.
-  Kernel.srand config.seed
-=end
+  # The settings below are suggested to provide a good initial experience
+  # with RSpec, but feel free to customize to your heart's content.
+  #   # This allows you to limit a spec run to individual examples or groups
+  #   # you care about by tagging them with `:focus` metadata. When nothing
+  #   # is tagged with `:focus`, all examples get run. RSpec also provides
+  #   # aliases for `it`, `describe`, and `context` that include `:focus`
+  #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  #   config.filter_run_when_matching :focus
+  #
+  #   # Allows RSpec to persist some state between runs in order to support
+  #   # the `--only-failures` and `--next-failure` CLI options. We recommend
+  #   # you configure your source control system to ignore this file.
+  #   config.example_status_persistence_file_path = "spec/examples.txt"
+  #
+  #   # Limits the available syntax to the non-monkey patched syntax that is
+  #   # recommended. For more details, see:
+  #   # https://relishapp.com/rspec/rspec-core/docs/configuration/zero-monkey-patching-mode
+  #   config.disable_monkey_patching!
+  #
+  #   # Many RSpec users commonly either run the entire suite or an individual
+  #   # file, and it's useful to allow more verbose output when running an
+  #   # individual spec file.
+  #   if config.files_to_run.one?
+  #     # Use the documentation formatter for detailed output,
+  #     # unless a formatter has already been configured
+  #     # (e.g. via a command-line flag).
+  #     config.default_formatter = "doc"
+  #   end
+  #
+  #   # Print the 10 slowest examples and example groups at the
+  #   # end of the spec run, to help surface which specs are running
+  #   # particularly slow.
+  #   config.profile_examples = 10
+  #
+  #   # Run specs in random order to surface order dependencies. If you find an
+  #   # order dependency and want to debug it, you can fix the order by providing
+  #   # the seed, which is printed after each run.
+  #   #     --seed 1234
+  #   config.order = :random
+  #
+  #   # Seed global randomization in this process using the `--seed` CLI option.
+  #   # Setting this allows you to use `--seed` to deterministically reproduce
+  #   # test failures related to randomization by passing the same `--seed` value
+  #   # as the one that triggered the failure.
+  #   Kernel.srand config.seed
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   driven_by :selenium, using: :chrome, screen_size: [1400, 1400]

--- a/test/channels/application_cable/connection_test.rb
+++ b/test/channels/application_cable/connection_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase
   # test "connects with cookies" do

--- a/test/controllers/items_controller_test.rb
+++ b/test/controllers/items_controller_test.rb
@@ -1,9 +1,8 @@
 require 'test_helper'
 
 class ItemsControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
+  test 'should get index' do
     get items_index_url
     assert_response :success
   end
-
 end


### PR DESCRIPTION
# why
商品一覧表示機能の実装

# what
出品商品がトップページに新しい順に表示されるようにする
※商品購入機能未実装のため、購入されていなくてもsold outの表示となっています。

# 確認用Gyazoo
- 商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/18a49303c3e7fecd3f302ca568f9d703

- 商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/d28610ea31befe104497753250e01f19